### PR TITLE
Fix Pod "missing license" warning

### DIFF
--- a/PinCodeTextField.podspec
+++ b/PinCodeTextField.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "https://github.com/tkach/PinCodeTextField"
 
-  s.license      = { :type => "MIT", :file => 'MIT-LICENSE.txt' }
+  s.license      = { :type => "MIT" }
 
 
   s.author       = { "Alex Tkachenko" => "tkach2004@gmail.com" }


### PR DESCRIPTION
This PR fixes the following warning when installing the PinCodeTextField pod:

```
[!] Unable to read the license file `<pathTo>/PinCodeTextField/MIT-LICENSE.txt` 
for the spec `PinCodeTextField (0.0.4)`
```

This warning occurs because the `MIT-LICENSE.txt` file does not exist. Since the project is set up with a `LICENSE` file in the root dir, the file key can be omitted.

Now, when installing the PinCodeTextField pod the warning does not display.