### PR TITLE
Use border instead of underline

### DIFF
--- a/Pod/PinCodeTextField.swift
+++ b/Pod/PinCodeTextField.swift
@@ -207,15 +207,15 @@ import UIKit
         }
     }
 
+    private func underlineColorForIndex(_ index: Int) -> UIColor {
+        (!highlightInputUnderline || !isInput(index)) && isPlaceholder(index)
+            ? underlineColor
+            : updatedUnderlineColor
+    }
+
     private func updateUnderlines() {
-        for label in labels {
-            let index = labels.firstIndex(of: label) ?? 0
-            if (!highlightInputUnderline || !isInput(index)) && isPlaceholder(index) {
-                   underlines[index].backgroundColor = underlineColor
-            }
-            else{
-                underlines[index].backgroundColor = updatedUnderlineColor
-            }
+        for (index, underline) in underlines.enumerated() {
+            underline.backgroundColor = underlineColorForIndex(index)
         }
     }
     

--- a/Pod/PinCodeTextField.swift
+++ b/Pod/PinCodeTextField.swift
@@ -45,7 +45,8 @@ import UIKit
     @IBInspectable public var characterBackgroundColor: UIColor = UIColor.clear
     @IBInspectable public var characterBackgroundCornerRadius: CGFloat = 0
     @IBInspectable public var highlightInputUnderline: Bool = false
-    
+    @IBInspectable public var showBorderInsteadOfUnderline: Bool = false
+
     //MARK: Customizable from code
     public var keyboardType: UIKeyboardType = UIKeyboardType.alphabet
     public var keyboardAppearance: UIKeyboardAppearance = UIKeyboardAppearance.default
@@ -220,9 +221,13 @@ import UIKit
     }
     
     private func updateBackgrounds() {
-        for background in backgrounds {
+        for (index, background) in backgrounds.enumerated() {
             background.backgroundColor = characterBackgroundColor
             background.layer.cornerRadius = characterBackgroundCornerRadius
+            if showBorderInsteadOfUnderline {
+                background.layer.borderWidth = underlineHeight
+                background.layer.borderColor = underlineColorForIndex(index).cgColor
+            }
         }
     }
     
@@ -274,9 +279,12 @@ import UIKit
         let underlineY = bounds.height / 2 + totalLabelHeight / 2 + underlineVMargin
         
         for i in 0..<underlines.count {
-            let underline = underlines[i]
+            if !showBorderInsteadOfUnderline {
+                let underline = underlines[i]
+                underline.frame = CGRect(x: currentUnderlineX, y: underlineY, width: underlineWidth, height: underlineHeight)
+            }
+
             let background = backgrounds[i]
-            underline.frame = CGRect(x: currentUnderlineX, y: underlineY, width: underlineWidth, height: underlineHeight)
             background.frame = CGRect(x: currentUnderlineX, y: 0, width: underlineWidth, height: bounds.height)
             currentUnderlineX += underlineWidth + underlineHSpacing
         }


### PR DESCRIPTION
Hi,

my use case mandate that I use a border instead of an underline.
So I put a flag to apply the same underline configuration to the border.


![ezgif com-gif-maker](https://user-images.githubusercontent.com/814597/101206361-ca56cd00-364d-11eb-807e-4af03005109f.gif)
